### PR TITLE
windows start script created

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,24 @@
+echo off
+
+REM Extract script location
+SET SCRIPT_PATH=%~dp0
+SET SCRIPT_PATH=%SCRIPT_PATH:\=/%
+SET SCRIPT_PATH=%SCRIPT_PATH:~0,-1%
+
+REM Prefix 'sdg-server' has to match the parent deploy folder on the server.
+echo "sdg-server: Creating data volumes"
+docker volume create sdg-server_jekyll-data
+
+echo "sdg-server: Building Jekyll site"
+docker run --rm --volume="%SCRIPT_PATH%/jekyll:/srv/jekyll" --volume="jekyll-cache:/usr/local/bundle" -it jekyll/jekyll:latest jekyll build
+
+echo "sdg-server: Copying site to jekyll-data volume"
+docker run --name helper --volume="sdg-server_jekyll-data:/web" -it busybox true
+docker cp jekyll/web/. helper:/web
+docker rm helper
+
+echo "sdg-server: Building stack"
+docker-compose build
+
+echo "sdg-server: Starting stack"
+docker-compose up -d


### PR DESCRIPTION
Hey,
I created a port of the start script that can be used to start the toolstack on Windows systems. While using it I was running into an issue during Docker build process for the core module that is related to line ending characters that were used for the files `core/Pipfile` and `core/manage.py`. It can be fixed by changing line ending characters for these files to LF. For some reason, I was not able to commit this change via Git client.
The issues is described [here](https://askubuntu.com/questions/896860/usr-bin-env-python3-r-no-such-file-or-directory).