### PR TITLE
Fix channels-django routing bug

### DIFF
--- a/core/core/routing.py
+++ b/core/core/routing.py
@@ -1,11 +1,13 @@
-from django.urls import path
 from channels.routing import ProtocolTypeRouter, URLRouter
+from django.core.asgi import get_asgi_application
+from django.urls import path
 
 from farms.consumers import ControllerConsumer
 from farms.utils import TokenAuthMiddleware
 
 application = ProtocolTypeRouter(
     {
+        "http": get_asgi_application(),
         "websocket": TokenAuthMiddleware(
             URLRouter(
                 [

--- a/production.yml
+++ b/production.yml
@@ -14,9 +14,9 @@ services:
       - 'core/secrets.core'
       - 'core/env.rabbitmq'
       - 'core/secrets.rabbitmq'
-      - 'grafana/env.grafana'
-      - 'grafana/secrets.grafana'
-      - 'influxdb/secrets.influxdb'
+      # - 'grafana/env.grafana'
+      # - 'grafana/secrets.grafana'
+      # - 'influxdb/secrets.influxdb'
       - 'postgres/secrets.postgres'
       - 'redis/env.redis'
       - 'redis/secrets.redis'
@@ -24,22 +24,22 @@ services:
       - backend
       - frontend
     depends_on:
-      - influxdb
+      # - influxdb
       # - grafana
       - postgres
     labels:
     - "traefik.enable=true"
-    - "traefik.http.routers.staging-ofai-core.rule=Host(`core.staging.openfarming.ai`)"
-    - "traefik.http.routers.staging-ofai-core.entrypoints=web"
-    - "traefik.http.routers.staging-ofai-core.service=noop@internal"
-    - "traefik.http.routers.staging-ofai-core.middlewares=staging-ofai-core-https-redirect"
-    - "traefik.http.middlewares.staging-ofai-core-https-redirect.redirectscheme.scheme=https"
+    - "traefik.http.routers.production-ofai-core.rule=Host(`core.openfarming.ai`)"
+    - "traefik.http.routers.production-ofai-core.entrypoints=web"
+    - "traefik.http.routers.production-ofai-core.service=noop@internal"
+    - "traefik.http.routers.production-ofai-core.middlewares=production-ofai-core-https-redirect"
+    - "traefik.http.middlewares.production-ofai-core-https-redirect.redirectscheme.scheme=https"
 
-    - "traefik.http.routers.staging-ofai-core-secure.rule=Host(`core.staging.openfarming.ai`)"
-    - "traefik.http.routers.staging-ofai-core-secure.entrypoints=websecure"
-    - "traefik.http.routers.staging-ofai-core-secure.service=staging-ofai-core-service"
-    - "traefik.http.routers.staging-ofai-core-secure.tls.certresolver=myresolver"
-    - "traefik.http.services.staging-ofai-core-service.loadbalancer.server.port=8000"
+    - "traefik.http.routers.production-ofai-core-secure.rule=Host(`core.openfarming.ai`)"
+    - "traefik.http.routers.production-ofai-core-secure.entrypoints=websecure"
+    - "traefik.http.routers.production-ofai-core-secure.service=production-ofai-core-service"
+    - "traefik.http.routers.production-ofai-core-secure.tls.certresolver=myresolver"
+    - "traefik.http.services.production-ofai-core-service.loadbalancer.server.port=8000"
     - "traefik.docker.network=gateway"
 
   # grafana:
@@ -81,7 +81,7 @@ services:
 ## App Backend
   postgres:
     image: timescale/timescaledb:latest-pg12
-    container_name: postgres
+    # container_name: postgres
     restart: always
     logging:
       options:
@@ -94,25 +94,25 @@ services:
     volumes:
       - postgres-data-12:/var/lib/postgresql/data
 
-  influxdb:
-    image: influxdb:1.5
-    container_name: influxdb
-    restart: always
-    logging:
-      options:
-        max-size: '2m'
-        max-file: '10'
-    env_file:
-      - 'influxdb/env.influxdb'
-      - 'influxdb/secrets.influxdb'
-    networks:
-      - backend
-    volumes:
-      - influxdb-data:/var/lib/influxdb
+  # influxdb:
+  #   image: influxdb:1.5
+  #   container_name: influxdb
+  #   restart: always
+  #   logging:
+  #     options:
+  #       max-size: '2m'
+  #       max-file: '10'
+  #   env_file:
+  #     - 'influxdb/env.influxdb'
+  #     - 'influxdb/secrets.influxdb'
+  #   networks:
+  #     - backend
+  #   volumes:
+  #     - influxdb-data:/var/lib/influxdb
 
   redis:
     image: redis:6.0.8-alpine
-    container_name: redis
+    # container_name: redis
     restart: always
     command: |
       sh -c "\
@@ -128,7 +128,7 @@ services:
     
   rabbitmq:
     image: rabbitmq:3
-    container_name: rabbitmq
+    # container_name: rabbitmq
     restart: always
     logging:
       options:
@@ -149,8 +149,8 @@ networks:
       name: gateway
 
 volumes:
-  influxdb-data:
-  grafana-data:
-  grafana-config:
+  # influxdb-data:
+  # grafana-data:
+  # grafana-config:
   postgres-data-12:
   rabbitmq-data:


### PR DESCRIPTION
Why:

- Crash when visiting HTTP end-points

This change addresses the need by:

- Explicitly adding the asgi application to the ProtocolTypeRouter