### PR TITLE
Fix minio URL from core service

### DIFF
--- a/core/start.sh
+++ b/core/start.sh
@@ -209,11 +209,16 @@ while ! nc -z $MINIO_HOST $MINIO_PORT; do
   sleep 0.5 # wait for half a second before checking again
 done
 
-# Add the MinIO server URL
+# Add the MinIO server. Construct the URL for staging/prod or dev environment
+if [[ $DJANGO_DEBUG == "False" ]]; then
+  MINIO_URL="http://sdg-server-$DEPLOY_TYPE-$MINIO_HOST:$MINIO_PORT"
+else
+  MINIO_URL="http://$MINIO_HOST:$MINIO_PORT"
+fi
 ./mc alias set core-s3-server \
-  "http://$MINIO_HOST:$MINIO_PORT" \
-  "$MINIO_ROOT_USER" \
-  "$MINIO_ROOT_PASSWORD"
+    "$MINIO_URL" \
+    "$MINIO_ROOT_USER" \
+    "$MINIO_ROOT_PASSWORD"
 # If the user does not exist add them and the respective policy
 if ! ./mc admin user list core-s3-server | grep -q "$MINIO_ACCESS_KEY_ID"; then
   echo "Adding user $MINIO_ACCESS_KEY_ID and bucket policy to MinIO server"

--- a/production.yml
+++ b/production.yml
@@ -10,6 +10,8 @@ services:
       options:
         max-size: '2m'
         max-file: '10'
+    environment:
+      - DEPLOY_TYPE=${DEPLOY_TYPE}
     env_file:
       - 'core/env.core'
       - 'core/secrets.core'
@@ -25,6 +27,9 @@ services:
       - frontend
     depends_on:
       - postgres
+      - minio
+      - redis
+      - rabbitmq
     labels:
     - "traefik.enable=true"
     - "traefik.http.routers.sdg-server-${DEPLOY_TYPE}-core.rule=Host(`${CORE_DOMAIN}`)"


### PR DESCRIPTION
The URL used by the core service to contact the minio service was identical for
the production and staging services. This led to a conflict when performing the
setup and during operation.

The fix causes the prod/staging environment to use the container name instead
of the service name, which is the same for both instances. The container name
has the format of 'sdg-server-$DEPLOY_TYPE-minio'. This also required passing
the deploy type as a variable into the core service.