### PR TITLE
Fix plant GraphQL queries

### DIFF
--- a/core/greenhouse/graphql/nodes.py
+++ b/core/greenhouse/graphql/nodes.py
@@ -80,6 +80,8 @@ class PlantComponentNode(DjangoObjectType):
             "modified_at": ["exact", "lt", "gt"],
         }
         fields = (
+            "hydroponic_system",
+            "plant_image_set",
             "site_entity",
             "spot_number",
             "species",

--- a/core/greenhouse/models/plant_image.py
+++ b/core/greenhouse/models/plant_image.py
@@ -46,6 +46,7 @@ class PlantImage(models.Model):
     plant = models.ForeignKey(
         PlantComponent,
         on_delete=models.CASCADE,
+        related_name="plant_image_set",
         help_text="The primary plant in the image.",
     )
     created_at = models.DateTimeField(


### PR DESCRIPTION
Why:

- Allow querying the hydroponic system and plant image set of a plant

This change addresses the need by:

- Adding the required fields to the plant GraphQL node
- Updating the related name for plant images